### PR TITLE
added swagger docs redirect to host if defined in env config of mia-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.2 (February 22, 2019)
+* Added redir for swagger host if defined in env config
+
 ## 2.4.1 (February 22, 2019)
 * Fixed log output if dead servers were killed
 

--- a/lib/routesHandler/lib/swaggerDocs.js
+++ b/lib/routesHandler/lib/swaggerDocs.js
@@ -524,6 +524,18 @@ function thisModule() {
                             res.json(swaggerSpec);
                         });
                         hosts[hostId]["router"].get('/docs', (req, res) => {
+
+                            const env = Shared.config('environment')
+                            const swaggerHost = _.get(env, 'swagger.host')
+                            const protocol = req.headers && req.headers['x-forwarded-proto'] ? req.headers['x-forwarded-proto'] : req.protocol
+                            const currentHost = req.headers.host
+
+                            if (swaggerHost && currentHost !== swaggerHost) {
+                              const redirUrl = protocol + '://' + swaggerHost + '/docs'
+                              res.redirect(301, redirUrl)
+                              return
+                            }
+
                             if (!req.originalUrl.endsWith('/')) {
                                 res.redirect(301, req.originalUrl + '/');
                                 return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mia-js-core",
-  "version": "2.3.4",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "middleware",
     "framework"
   ],
-  "version": "2.4.1",
+  "version": "2.4.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/7factory/mia-js-core.git"


### PR DESCRIPTION
To test it add the following to env config and replace xxx with a redir url

`swagger: {
    "host": "xxxxxxxx"
  },`